### PR TITLE
Changes for trino 369

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ keywords = bloomberg, Bloomberg, datalake
 packages = find_namespace:
 install_requires =
     confluent_kafka
+    python-dateutil
     pyyaml
     sqlalchemy
     tenacity

--- a/src/bloomberg/datalake/datalakequerydbconsumer/_data_models.py
+++ b/src/bloomberg/datalake/datalakequerydbconsumer/_data_models.py
@@ -97,8 +97,12 @@ def _get_datetime_from_field(field: str | int | float | datetime) -> datetime:
         return datetime.fromtimestamp(float(field))
     elif isinstance(field, str):
         return parser.parse(field)
-    else:
+    elif isinstance(field, datetime):
         return field
+    else:
+        raise TypeError(
+            f"Invalid argument: {field=} should be a string, integer, float or datetime object, not {type(field)}"
+        )
 
 
 def get_query_metrics_from_raw(raw_metrics: dict[str, Any]) -> QueryMetrics:

--- a/tests/integration/test_db_accessor.py
+++ b/tests/integration/test_db_accessor.py
@@ -146,3 +146,109 @@ def test_add_column_metrics(session: Session):
     assert result[2].columnName == "test-column-2_1"
     assert result[2].physicalInputBytes == 0
     assert result[2].physicalInputRows == 2
+
+
+@pytest.mark.usefixtures("_cleanup")
+def test_nullable_column(session: Session):
+    # Given
+    (_query_id, _raw_metrics) = get_raw_metrics()
+    del _raw_metrics["statistics"]["peakTotalNonRevocableMemoryBytes"]
+
+    # When
+    _add_query_metrics(_raw_metrics)
+
+    # Then
+    result = session.query(QueryMetrics).filter_by(queryId=_query_id).first()
+
+    assert result is not None
+    assert result.queryId == _query_id
+    assert result.transactionId == "3e7820f0-4a9e-498f-88d8-c206ac85bd3e"
+    assert result.query == "SELECT * FROM table;"
+    assert result.queryType == "SELECT"
+    assert result.remoteClientAddress == "127.0.0.1"
+    assert result.user == "test-user"
+    assert result.userAgent == "StatementClientV1/8012395-dirty"
+    assert result.source == "datalake-cli"
+    assert result.serverAddress == "localhost"
+    assert result.serverVersion == "dev"
+    assert result.environment == "test"
+    assert result.cpuTime == 25.975
+    assert result.wallTime == 112.444
+    assert result.queuedTime == 0.001
+    assert result.scheduledTime == 156.696
+    assert result.analysisTime == 12.178
+    assert result.planningTime == 1.733
+    assert result.executionTime == 100.266
+    assert result.peakUserMemoryBytes == 24610191
+    assert result.peakTaskUserMemory == 19472880
+    assert result.peakTaskTotalMemory == 43828971
+    assert result.physicalInputBytes == 0
+    assert result.physicalInputRows == 1293616
+    assert result.internalNetworkBytes == 49808906
+    assert result.internalNetworkRows == 1123864
+    assert result.totalBytes == 0
+    assert result.totalRows == 1293616
+    assert result.outputBytes == 9019074
+    assert result.outputRows == 160908
+    assert result.writtenBytes == 0
+    assert result.writtenRows == 0
+    assert result.cumulativeMemory == 2143774060571.0
+    assert result.completedSplits == 507
+    assert result.resourceWaitingTime == 12.178
+    assert result.createTime == datetime.fromtimestamp(1626773622)
+    assert result.executionStartTime == datetime.fromtimestamp(1626773634)
+    assert result.endTime == datetime.fromtimestamp(1626773734)
+
+
+@pytest.mark.usefixtures("_cleanup")
+def test_str_or_float_timestamps(session: Session):
+    # Given
+    (_query_id, _raw_metrics) = get_raw_metrics()
+    _raw_metrics["createTime"] = "2021-07-20T9:33:42.000Z"
+    _raw_metrics["endTime"] = 1626773734.0
+
+    # When
+    _add_query_metrics(_raw_metrics)
+
+    # Then
+    result = session.query(QueryMetrics).filter_by(queryId=_query_id).first()
+
+    assert result is not None
+    assert result.queryId == _query_id
+    assert result.transactionId == "3e7820f0-4a9e-498f-88d8-c206ac85bd3e"
+    assert result.query == "SELECT * FROM table;"
+    assert result.queryType == "SELECT"
+    assert result.remoteClientAddress == "127.0.0.1"
+    assert result.user == "test-user"
+    assert result.userAgent == "StatementClientV1/8012395-dirty"
+    assert result.source == "datalake-cli"
+    assert result.serverAddress == "localhost"
+    assert result.serverVersion == "dev"
+    assert result.environment == "test"
+    assert result.cpuTime == 25.975
+    assert result.wallTime == 112.444
+    assert result.queuedTime == 0.001
+    assert result.scheduledTime == 156.696
+    assert result.analysisTime == 12.178
+    assert result.planningTime == 1.733
+    assert result.executionTime == 100.266
+    assert result.peakUserMemoryBytes == 24610191
+    assert result.peakTotalNonRevocableMemoryBytes == 58178441
+    assert result.peakTaskUserMemory == 19472880
+    assert result.peakTaskTotalMemory == 43828971
+    assert result.physicalInputBytes == 0
+    assert result.physicalInputRows == 1293616
+    assert result.internalNetworkBytes == 49808906
+    assert result.internalNetworkRows == 1123864
+    assert result.totalBytes == 0
+    assert result.totalRows == 1293616
+    assert result.outputBytes == 9019074
+    assert result.outputRows == 160908
+    assert result.writtenBytes == 0
+    assert result.writtenRows == 0
+    assert result.cumulativeMemory == 2143774060571.0
+    assert result.completedSplits == 507
+    assert result.resourceWaitingTime == 12.178
+    assert result.createTime == datetime.fromtimestamp(1626773622)
+    assert result.executionStartTime == datetime.fromtimestamp(1626773634)
+    assert result.endTime == datetime.fromtimestamp(1626773734)


### PR DESCRIPTION
Trino 369 removes the property `peakTotalNonRevocableMemoryBytes ` from query statistics.
Trino 370 will change the format of timestamps from the `http-event-listener` from floats to strings like `2022-01-26T11:37:59.749Z`.

**Describe your changes**
Make peakTotalNonRevocableMemoryBytes field nullable.
Allow flexible time formats.

**Testing performed**
Added 2 tests for new functionality.
